### PR TITLE
Fix issue with starting before network

### DIFF
--- a/SOURCES/httpd.service
+++ b/SOURCES/httpd.service
@@ -1,5 +1,6 @@
 [Unit]
 Description=Apache web server managed by cPanel EasyApache
+After=network.target remote-fs.target nss-lookup.target
 ConditionPathExists=!/etc/httpddisable
 ConditionPathExists=!/etc/apachedisable
 ConditionPathExists=!/etc/httpdisable


### PR DESCRIPTION
Fix issue [found](https://serverfault.com/questions/858905/htaccess-proxy-rewrites-stop-working-after-server-reboot-on-centos-7/858908?noredirect=1#comment1104855_858908) on ServerFault with starting service before network interfaces is up.